### PR TITLE
Fix attribute name in scrapy list command

### DIFF
--- a/city_scrapers_core/commands/list.py
+++ b/city_scrapers_core/commands/list.py
@@ -5,5 +5,11 @@ class Command(ExistingListCommand):
     def run(self, args, opts):
         for s in sorted(self.crawler_process.spider_loader.list()):
             cls = self.crawler_process.spider_loader.load(s)
-            print("{0: <6} |  {1}".format(s, getattr(cls, "agency",
-                  getattr(cls, "agency_name", "Agency unavailable"))))
+            print(
+                "{0: <6} |  {1}".format(
+                    s,
+                    getattr(
+                        cls, "agency", getattr(cls, "agency_name", "Agency unavailable")
+                    ),
+                )
+            )

--- a/city_scrapers_core/commands/list.py
+++ b/city_scrapers_core/commands/list.py
@@ -5,4 +5,5 @@ class Command(ExistingListCommand):
     def run(self, args, opts):
         for s in sorted(self.crawler_process.spider_loader.list()):
             cls = self.crawler_process.spider_loader.load(s)
-            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", getattr(cls, "agency_name", "Agency unavailable"))))
+            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", 
+            	getattr(cls, "agency_name", "Agency unavailable"))))

--- a/city_scrapers_core/commands/list.py
+++ b/city_scrapers_core/commands/list.py
@@ -5,4 +5,4 @@ class Command(ExistingListCommand):
     def run(self, args, opts):
         for s in sorted(self.crawler_process.spider_loader.list()):
             cls = self.crawler_process.spider_loader.load(s)
-            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", cls.agency_name)))
+            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", cls.agency)))

--- a/city_scrapers_core/commands/list.py
+++ b/city_scrapers_core/commands/list.py
@@ -5,4 +5,4 @@ class Command(ExistingListCommand):
     def run(self, args, opts):
         for s in sorted(self.crawler_process.spider_loader.list()):
             cls = self.crawler_process.spider_loader.load(s)
-            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", cls.agency)))
+            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", getattr(cls, "agency_name", "Agency unavailable"))))

--- a/city_scrapers_core/commands/list.py
+++ b/city_scrapers_core/commands/list.py
@@ -5,5 +5,5 @@ class Command(ExistingListCommand):
     def run(self, args, opts):
         for s in sorted(self.crawler_process.spider_loader.list()):
             cls = self.crawler_process.spider_loader.load(s)
-            print("{0: <6} |  {1}".format(s, getattr(cls, "agency", 
-            	getattr(cls, "agency_name", "Agency unavailable"))))
+            print("{0: <6} |  {1}".format(s, getattr(cls, "agency",
+                  getattr(cls, "agency_name", "Agency unavailable"))))


### PR DESCRIPTION
At present, `scrapy list` throws an error because the command tries to get the attribute `agency_name` as opposed to `agency`, which is set in the `genspider` command here: https://github.com/City-Bureau/city-scrapers-core/blob/78db681f2bd635faec36ae0832f6b348437794e2/city_scrapers_core/commands/genspider.py#L31

Traceback:

```
(city-scrapers) jamesotoole@Jamess-MacBook-Pro-2 city-scrapers-pitt (master) $ scrapy list
alle_county |  Allegheny County Government
Traceback (most recent call last):
  File "/Users/jamesotoole/.pyenv/versions/city-scrapers/bin/scrapy", line 10, in <module>
    sys.exit(execute())
  File "/Users/jamesotoole/.pyenv/versions/3.6.4/envs/city-scrapers/lib/python3.6/site-packages/scrapy/cmdline.py", line 150, in execute
    _run_print_help(parser, _run_command, cmd, args, opts)
  File "/Users/jamesotoole/.pyenv/versions/3.6.4/envs/city-scrapers/lib/python3.6/site-packages/scrapy/cmdline.py", line 90, in _run_print_help
    func(*a, **kw)
  File "/Users/jamesotoole/.pyenv/versions/3.6.4/envs/city-scrapers/lib/python3.6/site-packages/scrapy/cmdline.py", line 157, in _run_command
    cmd.run(args, opts)
  File "/Users/jamesotoole/.pyenv/versions/3.6.4/envs/city-scrapers/lib/python3.6/site-packages/city_scrapers_core/commands/list.py", line 8, in run
    print("{0: <6} |  {1}".format(s, getattr(cls, "agency", cls.agency_name)))
AttributeError: type object 'AllePortAuthoritySpider' has no attribute 'agency_name'
```