### PR TITLE
Handle offset-aware datetime in _get_status

### DIFF
--- a/city_scrapers_core/spiders/spider.py
+++ b/city_scrapers_core/spiders/spider.py
@@ -13,12 +13,12 @@ class CityScrapersSpider(Spider):
         # Add parameters for feed storage in spider local time
         if not hasattr(self, "timezone"):
             self.timezone = "America/Chicago"
-        tz = timezone(self.timezone)
-        now = tz.localize(datetime.now())
-        self.year = now.year
-        self.month = now.strftime("%m")
-        self.day = now.strftime("%d")
-        self.hour_min = now.strftime("%H%M")
+        self.tz = timezone(self.timezone)
+        self.now = self.tz.localize(datetime.now())
+        self.year = self.now.year
+        self.month = self.now.strftime("%m")
+        self.day = self.now.strftime("%d")
+        self.hour_min = self.now.strftime("%H%M")
 
     def _clean_title(self, title):
         """Remove cancelled strings from title"""
@@ -48,8 +48,9 @@ class CityScrapersSpider(Spider):
         meeting_text = " ".join(
             [item.get("title", ""), item.get("description", ""), text]
         ).lower()
+        start_with_tz = self.tz.localize(item["start"])
         if any(word in meeting_text for word in ["cancel", "rescheduled", "postpone"]):
             return CANCELLED
-        if item["start"] < datetime.now():
+        if start_with_tz < self.now:
             return PASSED
         return TENTATIVE

--- a/tests/test_spiders.py
+++ b/tests/test_spiders.py
@@ -12,7 +12,7 @@ def spider():
 
 
 def test_spider_clean_title(spider):
-    assert spider._clean_title("  Test 12 : Canceledd ") == "Test 12"
+    assert spider._clean_title("  Test 12 : Canceled ") == "Test 12"
 
 
 def test_spider_get_id(spider):


### PR DESCRIPTION
I ran into an error in development in which the `_get_status` method tripped because I was passing it a timezone-aware `item["start"]` value: 

```
../../.pyenv/versions/3.6.4/envs/city-scrapers/lib/python3.6/site-packages/city_scrapers_core/spiders/spider.py:53: in _get_status
    if item["start"] < datetime.now():
E   TypeError: can't compare offset-naive and offset-aware datetimes
```

In making this change I thought it'd be most straightforward to have `tz` and `now` as instance variables, but happy to take a less aggressive approach 🙂 