### PR TITLE
Validate command should use add_argument for nested argparse object

### DIFF
--- a/city_scrapers_core/commands/validate.py
+++ b/city_scrapers_core/commands/validate.py
@@ -20,7 +20,7 @@ class Command(ScrapyCommand):
 
     def add_options(self, parser):
         ScrapyCommand.add_options(self, parser)
-        parser.add_option(
+        parser.add_argument(
             "--all",
             dest="all",
             action="store_true",

--- a/city_scrapers_core/extensions/status.py
+++ b/city_scrapers_core/extensions/status.py
@@ -60,8 +60,8 @@ class StatusExtension:
         self.update_status_svg(self.crawler.spider, svg)
 
     def spider_error(self):
-        """Sets the `has_error` flag on the first spider error and immediately updates the
-        SVG with a "failing" status
+        """Sets the `has_error` flag on the first spider error and immediately updates
+        the SVG with a "failing" status
         """
         self.has_error = True
         svg = self.create_status_svg(self.crawler.spider, FAILING)


### PR DESCRIPTION
## Summary 
**Issue:** #13 
argparse setup for shell command `validate --all` is currently using the wrong argparse method for adding an argument. This PR uses `add_argument` instead of `add_option`

## Status
Tests currently failing due to to package issues seemingly unrelated to the code change. Ready for review