### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
per devguide.python.org -  Python 3.7 & 3.8 are at end-of-life and unsupported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to test on Python 3.9–3.12.
  * Upgraded the Python setup action in CI to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->