### PR TITLE
Add last scraped date to meeting entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/city_scrapers_core/items.py
+++ b/city_scrapers_core/items.py
@@ -18,6 +18,7 @@ class Meeting(scrapy.Item):
     location = scrapy.Field()
     links = scrapy.Field()
     source = scrapy.Field()
+    last_scraped_date = scrapy.Field()
     jsonschema = {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Meeting Item",
@@ -83,6 +84,11 @@ class Meeting(scrapy.Item):
             },
             "links": {"type": "array"},
             "source": {"type": "string", "format": "url"},
+            "last_scraped_date": {
+                "type": "string",
+                "description": "When this meeting was scraped (ISO 8601 format)",
+                "format": "date-time",
+            },
         },
         "required": ["id", "title", "start", "source"],
     }

--- a/city_scrapers_core/pipelines/meeting.py
+++ b/city_scrapers_core/pipelines/meeting.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from scrapy import Item, Spider
 
@@ -19,6 +19,9 @@ class MeetingPipeline:
         :return: Processed item
         """
         item["title"] = spider._clean_title(item["title"])
+        item["last_scraped_date"] = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%f"
+        )
         # Set default end time of two hours later if end time is not present or if it's
         # the same time as the start
         if not item.get("end") or (

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 from scrapy.exceptions import DropItem
@@ -12,7 +12,7 @@ from city_scrapers_core.pipelines import (
     MeetingPipeline,
     ValidationPipeline,
 )
-from city_scrapers_core.spiders import CityScrapersSpider
+from city_scrapers_core.spiders import CityScrapersSpider, LegistarSpider
 
 
 def test_ignore_processed():
@@ -31,15 +31,40 @@ def test_ignore_processed():
 
 def test_meeting_pipeline_sets_end():
     pipeline = MeetingPipeline()
-    meeting = pipeline.process_item(
-        Meeting(title="Test", start=datetime.now()), CityScrapersSpider(name="test")
-    )
+    spider = CityScrapersSpider(name="test")
+    meeting = pipeline.process_item(Meeting(title="Test", start=datetime.now()), spider)
     assert meeting["end"] > meeting["start"]
     now = datetime.now()
-    meeting = pipeline.process_item(
-        Meeting(title="Test", start=now, end=now), CityScrapersSpider(name="test")
-    )
+    meeting = pipeline.process_item(Meeting(title="Test", start=now, end=now), spider)
     assert meeting["end"] > meeting["start"]
+
+
+def test_meeting_pipeline_sets_last_scraped_date():
+    pipeline = MeetingPipeline()
+    spider = CityScrapersSpider(name="test")
+    fixed_time = datetime(2025, 11, 19, 10, 0, 0, tzinfo=timezone.utc)
+
+    with patch("city_scrapers_core.pipelines.meeting.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed_time
+        meeting = pipeline.process_item(
+            Meeting(title="Test", start=datetime.now()), spider
+        )
+
+    assert meeting["last_scraped_date"] == "2025-11-19T10:00:00.000000"
+
+
+def test_meeting_pipeline_sets_last_scraped_date_legistar():
+    pipeline = MeetingPipeline()
+    spider = LegistarSpider(name="test")
+    fixed_time = datetime(2025, 11, 19, 10, 0, 0, tzinfo=timezone.utc)
+
+    with patch("city_scrapers_core.pipelines.meeting.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed_time
+        meeting = pipeline.process_item(
+            Meeting(title="Test", start=datetime.now()), spider
+        )
+
+    assert meeting["last_scraped_date"] == "2025-11-19T10:00:00.000000"
 
 
 def test_diff_merges_uids():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added last_scraped_date field to record when meetings were scraped in ISO 8601 datetime format.

* **Chores**
  * Updated CI workflow to test Python 3.9, 3.10, 3.11, and 3.12.
  * Upgraded Python setup action to newer version.

* **Tests**
  * Added tests verifying last_scraped_date is correctly set for meetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->