### PR TITLE
Mark status badge as failing when zero items scraped; upgrade CI to Python 3.10-3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,19 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install -r requirements.txt
 
       - run: python setup.py develop

--- a/city_scrapers_core/extensions/status.py
+++ b/city_scrapers_core/extensions/status.py
@@ -37,7 +37,6 @@ class StatusExtension:
     def __init__(self, crawler: Crawler):
         self.crawler = crawler
         self.has_error = False
-        # TODO: Track how many items are scraped on each run.
 
     @classmethod
     def from_crawler(cls, crawler: Crawler):
@@ -52,11 +51,13 @@ class StatusExtension:
 
     def spider_closed(self):
         """Updates the status SVG with a running status unless the spider has
-        encountered an error in which case it exits
+        encountered an error or scraped zero items, in which case it marks as failing.
         """
         if self.has_error:
             return
-        svg = self.create_status_svg(self.crawler.spider, RUNNING)
+        item_count = self.crawler.stats.get_value("item_scraped_count", 0)
+        status = FAILING if item_count == 0 else RUNNING
+        svg = self.create_status_svg(self.crawler.spider, status)
         self.update_status_svg(self.crawler.spider, svg)
 
     def spider_error(self):

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -6,6 +6,7 @@ from scrapy.exceptions import DropItem
 
 from city_scrapers_core.constants import CANCELLED
 from city_scrapers_core.decorators import ignore_processed
+from city_scrapers_core.extensions.status import FAILING, RUNNING, StatusExtension
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.pipelines import (
     DiffPipeline,
@@ -131,3 +132,43 @@ def test_validation_throws_error():
         pipeline.validation_report(spider_mock)
     pipeline.error_count["links"] = 0
     pipeline.validation_report(spider_mock)
+
+
+def _make_status_extension(item_count=0, has_error=False):
+    """Create a StatusExtension with a mocked crawler."""
+    crawler = MagicMock()
+    crawler.stats.get_value.return_value = item_count
+    crawler.spider.name = "test_spider"
+    crawler.spider.timezone = "America/Chicago"
+
+    ext = StatusExtension(crawler)
+    ext.has_error = has_error
+    ext.update_status_svg = MagicMock()
+    return ext
+
+
+def test_status_failing_when_zero_items():
+    ext = _make_status_extension(item_count=0)
+    ext.spider_closed()
+
+    ext.update_status_svg.assert_called_once()
+    svg = ext.update_status_svg.call_args[0][1]
+    assert FAILING in svg
+    assert RUNNING not in svg
+
+
+def test_status_running_when_items_scraped():
+    ext = _make_status_extension(item_count=5)
+    ext.spider_closed()
+
+    ext.update_status_svg.assert_called_once()
+    svg = ext.update_status_svg.call_args[0][1]
+    assert RUNNING in svg
+    assert FAILING not in svg
+
+
+def test_status_failing_on_error_overrides_items():
+    ext = _make_status_extension(item_count=10, has_error=True)
+    ext.spider_closed()
+
+    ext.update_status_svg.assert_not_called()


### PR DESCRIPTION
## Summary
- Scrapers that complete without errors but produce zero items now get a **failing** badge instead of misleadingly showing **running**
- Uses Scrapy's built-in `item_scraped_count` stat — no custom counting needed
- Removed the TODO comment that called for this feature

## Test plan
- [ ] `test_status_failing_when_zero_items` — 0 items → FAILING badge
- [ ] `test_status_running_when_items_scraped` — >0 items → RUNNING badge
- [ ] `test_status_failing_on_error_overrides_items` — error flag takes priority, no SVG update
- [ ] Full test suite passes (`pytest tests/`)