### PR TITLE
Fix deploy workflow: update Python 3.8 to 3.12 and actions to v4/v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Update Python 3.8 to 3.12 (3.8 no longer available on GitHub Actions)
- Update actions/checkout v1 to v4 and actions/setup-python v1 to v5