### PR TITLE
Update domain: cityscrapers.org -> city-scrapers.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/city-scrapers-core/badge/?version=latest)](https://city-scrapers-core.readthedocs.io/en/latest/?badge=latest)
 [![pypi](https://img.shields.io/pypi/v/city-scrapers-core)](https://pypi.org/project/city-scrapers-core/)
 
-Core functionality for creating public meetings web scrapers for the [City Scrapers](https://cityscrapers.org/) project.
+Core functionality for creating public meetings web scrapers for the [City Scrapers](https://city-scrapers.org/) project.
 
 See the [documentation](https://city-scrapers-core.readthedocs.io/) for more details.
 

--- a/city_scrapers_core/constants.py
+++ b/city_scrapers_core/constants.py
@@ -1,4 +1,4 @@
-NAMESPACE = "cityscrapers.org"
+NAMESPACE = "cityscrapers"
 
 ADVISORY_COMMITTEE = "Advisory Committee"
 BOARD = "Board"

--- a/city_scrapers_core/pipelines/diff.py
+++ b/city_scrapers_core/pipelines/diff.py
@@ -53,7 +53,7 @@ class DiffPipeline:
             crawler.spider._previous_map = {}
             for result in crawler.spider._previous_results:
                 extras_dict = result.get("extras") or result.get("extra") or {}
-                previous_id = extras_dict.get("cityscrapers.org/id")
+                previous_id = extras_dict.get("cityscrapers/id")
                 crawler.spider._previous_map[previous_id] = result["_id"]
         crawler.spider._scraped_ids = set()
         crawler.signals.connect(pipeline.spider_idle, signal=signals.spider_idle)
@@ -84,7 +84,7 @@ class DiffPipeline:
             return item
         if self.output_format == "ocd":
             extras_dict = item.get("extras") or item.get("extra") or {}
-            scraper_id = extras_dict.get("cityscrapers.org/id", "")
+            scraper_id = extras_dict.get("cityscrapers/id", "")
 
         # Drop items that are already included or are in the past
         dt_str = datetime.now().isoformat()[:19]

--- a/city_scrapers_core/pipelines/diff.py
+++ b/city_scrapers_core/pipelines/diff.py
@@ -53,7 +53,7 @@ class DiffPipeline:
             crawler.spider._previous_map = {}
             for result in crawler.spider._previous_results:
                 extras_dict = result.get("extras") or result.get("extra") or {}
-                previous_id = extras_dict.get("cityscrapers/id")
+                previous_id = extras_dict.get("cityscrapers/id") or extras_dict.get("cityscrapers.org/id")
                 crawler.spider._previous_map[previous_id] = result["_id"]
         crawler.spider._scraped_ids = set()
         crawler.signals.connect(pipeline.spider_idle, signal=signals.spider_idle)
@@ -84,7 +84,7 @@ class DiffPipeline:
             return item
         if self.output_format == "ocd":
             extras_dict = item.get("extras") or item.get("extra") or {}
-            scraper_id = extras_dict.get("cityscrapers/id", "")
+            scraper_id = extras_dict.get("cityscrapers/id") or extras_dict.get("cityscrapers.org/id") or ""
 
         # Drop items that are already included or are in the past
         dt_str = datetime.now().isoformat()[:19]

--- a/city_scrapers_core/pipelines/diff.py
+++ b/city_scrapers_core/pipelines/diff.py
@@ -53,7 +53,9 @@ class DiffPipeline:
             crawler.spider._previous_map = {}
             for result in crawler.spider._previous_results:
                 extras_dict = result.get("extras") or result.get("extra") or {}
-                previous_id = extras_dict.get("cityscrapers/id") or extras_dict.get("cityscrapers.org/id")
+                previous_id = extras_dict.get("cityscrapers/id") or extras_dict.get(
+                    "cityscrapers.org/id"
+                )
                 crawler.spider._previous_map[previous_id] = result["_id"]
         crawler.spider._scraped_ids = set()
         crawler.signals.connect(pipeline.spider_idle, signal=signals.spider_idle)
@@ -84,7 +86,11 @@ class DiffPipeline:
             return item
         if self.output_format == "ocd":
             extras_dict = item.get("extras") or item.get("extra") or {}
-            scraper_id = extras_dict.get("cityscrapers/id") or extras_dict.get("cityscrapers.org/id") or ""
+            scraper_id = (
+                extras_dict.get("cityscrapers/id")
+                or extras_dict.get("cityscrapers.org/id")
+                or ""
+            )
 
         # Drop items that are already included or are in the past
         dt_str = datetime.now().isoformat()[:19]

--- a/city_scrapers_core/pipelines/ocd.py
+++ b/city_scrapers_core/pipelines/ocd.py
@@ -52,10 +52,10 @@ class OpenCivicDataPipeline:
                 }
             ],
             "extras": {
-                "cityscrapers.org/id": item["id"],
-                "cityscrapers.org/agency": spider.agency,
-                "cityscrapers.org/time_notes": item.get("time_notes", ""),
-                "cityscrapers.org/address": item["location"]["address"],
+                "cityscrapers/id": item["id"],
+                "cityscrapers/agency": spider.agency,
+                "cityscrapers/time_notes": item.get("time_notes", ""),
+                "cityscrapers/address": item["location"]["address"],
             },
         }
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -62,7 +62,7 @@ def test_diff_ignores_previous_items():
     previous = {
         "_id": "1",
         "start": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S"),
-        "extras": {"cityscrapers.org/id": "1"},
+        "extras": {"cityscrapers/id": "1"},
     }
     spider_mock._previous_results = [previous]
     with pytest.raises(DropItem):
@@ -76,11 +76,11 @@ def test_diff_cancels_upcoming_previous_items():
     previous = {
         "_id": "1",
         "start": (now + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S"),
-        "extras": {"cityscrapers.org/id": "1"},
+        "extras": {"cityscrapers/id": "1"},
     }
     spider_mock.previous_results = [previous]
     result = pipeline.process_item(previous, spider_mock)
-    assert result["extras"]["cityscrapers.org/id"] == "1"
+    assert result["extras"]["cityscrapers/id"] == "1"
     assert result["status"] == CANCELLED
 
 


### PR DESCRIPTION
## Summary
- Update data namespace keys: `cityscrapers.org/*` -> `cityscrapers/*`
- Update URLs and User-Agent strings: `cityscrapers.org` -> `city-scrapers.org`

## Test plan
- [ ] Verify all `cityscrapers.org` references are updated
- [ ] Run existing tests to confirm no regressions