### PR TITLE
Reusable Airtable sync workflow

### DIFF
--- a/.github/scripts/sync_airtable.py
+++ b/.github/scripts/sync_airtable.py
@@ -195,10 +195,10 @@ def sync_to_airtable(
 
 def main():
     try:
-        pat = config("AIRTABLE_PAT")
-        base_id = config("AIRTABLE_BASE_ID")
-        slugs_table = config("SLUGS_TABLE_ID")
-        backlog_table = config("BACKLOG_TABLE_ID")
+        pat = config("CS_AIRTABLE_PAT")
+        base_id = config("CS_AIRTABLE_BASE_ID")
+        slugs_table = config("CS_SLUGS_TABLE_ID")
+        backlog_table = config("CS_BACKLOG_TABLE_ID")
     except UndefinedValueError as e:
         sys.exit(f"[ERROR] Missing env var: {e}")
 

--- a/.github/scripts/sync_airtable.py
+++ b/.github/scripts/sync_airtable.py
@@ -95,12 +95,9 @@ def extract_spiders(source: str) -> list[dict]:
 def find_program_for_agency(agency: str, backlog_table) -> str | None:
     """Look up `agency` in the Backlog table and return the linked Program record ID.
 
-    The Backlog table's Program field is a *lookup* (not a link), so it returns
-    the program's name as a string rather than a record ID. To get a record ID
-    suitable for writing to a 'link to another record' field on the Slugs table,
-    we have to take that name and look it up in the Programs table.
-
-    Returns the Programs record ID, or None if the agency isn't in Backlog or
+    The Backlog table's Program field is a *lookup*, it returns
+    the linked program's record ID. This function Returns the
+    Programs record ID, or None if the agency isn't in Backlog or
     the looked-up Program name doesn't resolve to a Programs record.
     """
     backlog_records = backlog_table.all(
@@ -121,7 +118,7 @@ def find_program_for_agency(agency: str, backlog_table) -> str | None:
 
 
 def sync_to_airtable(
-    spiders: list[dict], table, program_record_id: str | None = None
+    spiders: list[dict], table, table_records, program_record_id: str | None = None
 ) -> dict:
     """
     Sync spiders to Airtable, keyed on agency name.
@@ -149,7 +146,7 @@ def sync_to_airtable(
     Returns a summary: {'created': [...], 'updated': [...], 'skipped': [...]}.
     """
     existing: dict[str, tuple[str, str]] = {}
-    for row in table.all(fields=[SLUG_FIELD, AGENCY_FIELD]):
+    for row in table_records:
         agency = row["fields"].get(AGENCY_FIELD)
         if agency:
             existing[agency] = (row["id"], row["fields"].get(SLUG_FIELD, ""))
@@ -216,6 +213,8 @@ def main():
     slugs_table = api.table(base_id, slugs_table)
     backlog_table = api.table(base_id, backlog_table)
 
+    slugs_table_records = slugs_table.all(fields=[SLUG_FIELD, AGENCY_FIELD])
+
     # Process each file separately so all spiders from one factory file
     # share the same Program (looked up via the file's first spider agency).
     overall = {"created": [], "updated": [], "skipped": []}
@@ -240,7 +239,7 @@ def main():
         else:
             print(f"[INFO] No Program match for '{first_agency}'")
 
-        result = sync_to_airtable(spiders, slugs_table, program_id)
+        result = sync_to_airtable(spiders, slugs_table, slugs_table_records, program_id)
         for key in overall:
             overall[key].extend(result[key])
 

--- a/.github/scripts/sync_airtable.py
+++ b/.github/scripts/sync_airtable.py
@@ -1,0 +1,255 @@
+"""
+Sync spider slugs from changed spider files to Airtable.
+
+For each spider file passed in, extract all (name, agency) pairs and
+create/update Airtable records.
+
+The extraction of spiders currently only works for the following
+two patterns:
+    1. Singular scraper — a class whose body has `name = "..."` and
+         `agency = "..."` as direct class attributes. Only top-level class
+         assignments count; anything inside a method is ignored.
+    2. Spider factory — a module-level `spider_configs = [{...}, ...]`
+         list of dicts, each with its own "name" and "agency" keys.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+from decouple import UndefinedValueError, config
+from pyairtable import Api
+from pyairtable.formulas import match
+
+"""
+AirTable field names for the slug and agency name.
+These should match the field names in the AirTable base.
+"""
+# Spiders table field names
+SLUG_FIELD = "Slug"
+AGENCY_FIELD = "Agency name"
+PROGRAM_FIELD = "Program"
+
+# Backlog table field names
+BACKLOG_AGENCY_FIELD = "Agency name"
+BACKLOG_PROGRAM_LOOKUP_FIELD = "Program"
+
+
+def extract_spiders(source: str) -> list[dict]:
+    tree = ast.parse(source)
+    spiders: list[dict] = []
+
+    """
+    Helper function that finds `key = "..."` in a list of statements
+    and return the string. Only looks at direct Assign nodes in the
+    given body - doesn't recurse into nested functions or classes.
+    """
+
+    def get_str_assign(body, key):
+        for stmt in body:
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id == key
+                and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)
+            ):
+                return stmt.value.value
+        return None
+
+    for node in ast.iter_child_nodes(tree):
+        # Case 1: regular scraper
+        if isinstance(node, ast.ClassDef):
+            name = get_str_assign(node.body, "name")
+            agency = get_str_assign(node.body, "agency")
+            if name:
+                spiders.append({"name": name, "agency": agency})
+
+        # Case 2: spider factory
+        elif (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "spider_configs"
+                for t in node.targets
+            )
+            and isinstance(node.value, (ast.List, ast.Tuple))
+        ):
+            for element in node.value.elts:
+                if not isinstance(element, ast.Dict):
+                    continue
+                entry = {"name": None, "agency": None}
+                for k, v in zip(element.keys, element.values):
+                    if not (
+                        isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
+                    ):
+                        continue
+                    if k.value in ("name", "agency") and isinstance(v.value, str):
+                        entry[k.value] = v.value
+                if entry["name"]:
+                    spiders.append(entry)
+
+    return spiders
+
+
+def find_program_for_agency(agency: str, backlog_table) -> str | None:
+    """Look up `agency` in the Backlog table and return the linked Program record ID.
+
+    The Backlog table's Program field is a *lookup* (not a link), so it returns
+    the program's name as a string rather than a record ID. To get a record ID
+    suitable for writing to a 'link to another record' field on the Slugs table,
+    we have to take that name and look it up in the Programs table.
+
+    Returns the Programs record ID, or None if the agency isn't in Backlog or
+    the looked-up Program name doesn't resolve to a Programs record.
+    """
+    backlog_records = backlog_table.all(
+        formula=match({BACKLOG_AGENCY_FIELD: agency}),
+        fields=[BACKLOG_PROGRAM_LOOKUP_FIELD],
+        max_records=1,
+    )
+    if not backlog_records:
+        return None
+
+    # Lookup fields always return a list, even when the source link is single.
+    program_lookup = (
+        backlog_records[0]["fields"].get(BACKLOG_PROGRAM_LOOKUP_FIELD) or []
+    )
+    if not program_lookup:
+        return None
+    return program_lookup[0]
+
+
+def sync_to_airtable(
+    spiders: list[dict], table, program_record_id: str | None = None
+) -> dict:
+    """
+    Sync spiders to Airtable, keyed on agency name.
+    Agency name is considered the source of truth for
+    matching records.
+
+    Workflow for each spider:
+      - If the agency is already in the table and the slug matches: skip.
+      - If the agency is in the table but the slug differs: update the slug.
+      - If the agency is not in the table: create a new record.
+
+    If `program_record_id` is provided, every created or updated record also
+    has its Program field set to link to that record. If None, the Program
+    field is left untouched.
+
+    Note:
+    If the agency name for the same slug changes, a new record
+    will be created and the table will end up with multiple
+    records for the same slug but different agency names.
+    There would have to be some manual cleanup to remove the
+    old record with the outdated slug, but this is a safer
+    approach than accidentally overwriting an existing record
+    with a new slug that belongs to a different agency.
+
+    Returns a summary: {'created': [...], 'updated': [...], 'skipped': [...]}.
+    """
+    existing: dict[str, tuple[str, str]] = {}
+    for row in table.all(fields=[SLUG_FIELD, AGENCY_FIELD]):
+        agency = row["fields"].get(AGENCY_FIELD)
+        if agency:
+            existing[agency] = (row["id"], row["fields"].get(SLUG_FIELD, ""))
+
+    to_create = []
+    to_update = []
+    skipped = []
+
+    for spider in spiders:
+        slug = spider["name"]
+        agency = spider.get("agency")
+        if not agency:
+            # Can't key on agency if it's missing — log and move on.
+            print(f"[INFO] skipping spider '{slug}' — no agency name found")
+            continue
+
+        if agency in existing:
+            record_id, current_slug = existing[agency]
+            if current_slug == slug:
+                skipped.append(agency)
+            else:
+                fields = {SLUG_FIELD: slug}
+                if program_record_id:
+                    fields[PROGRAM_FIELD] = [program_record_id]
+                to_update.append({"id": record_id, "fields": fields})
+        else:
+            fields = {SLUG_FIELD: slug, AGENCY_FIELD: agency}
+            if program_record_id:
+                fields[PROGRAM_FIELD] = [program_record_id]
+            to_create.append(fields)
+            # Track in-memory so duplicates within this same run don't double-create.
+            existing[agency] = ("", slug)
+
+    created = []
+    if to_create:
+        created_records = table.batch_create(to_create)
+        created = [row["fields"].get(AGENCY_FIELD) for row in created_records]
+
+    updated = []
+    if to_update:
+        table.batch_update(to_update)
+        updated = [row["fields"][SLUG_FIELD] for row in to_update]
+
+    return {"created": created, "updated": updated, "skipped": skipped}
+
+
+def main():
+    try:
+        pat = config("AIRTABLE_PAT")
+        base_id = config("AIRTABLE_BASE_ID")
+        slugs_table = config("SLUGS_TABLE_ID")
+        backlog_table = config("BACKLOG_TABLE_ID")
+    except UndefinedValueError as e:
+        sys.exit(f"[ERROR] Missing env var: {e}")
+
+    files = [
+        Path(p) for p in sys.argv[1:] if Path(p).suffix == ".py" and Path(p).exists()
+    ]
+    if not files:
+        print("[INFO] No spider files to process.")
+        return
+
+    api = Api(pat)
+    slugs_table = api.table(base_id, slugs_table)
+    backlog_table = api.table(base_id, backlog_table)
+
+    # Process each file separately so all spiders from one factory file
+    # share the same Program (looked up via the file's first spider agency).
+    overall = {"created": [], "updated": [], "skipped": []}
+    for path in files:
+        try:
+            spiders = extract_spiders(path.read_text(encoding="utf-8"))
+        except SyntaxError as e:
+            print(f"  ! skipping {path} — syntax error: {e}")
+            continue
+
+        if not spiders:
+            print(f"  {path}: no spiders found")
+            continue
+
+        first_agency = spiders[0].get("agency")
+        program_id = None
+        if first_agency:
+            program_id = find_program_for_agency(first_agency, backlog_table)
+
+        if program_id:
+            print(f"[INFO] Found Program record {program_id} for {first_agency}")
+        else:
+            print(f"[INFO] No Program match for '{first_agency}'")
+
+        result = sync_to_airtable(spiders, slugs_table, program_id)
+        for key in overall:
+            overall[key].extend(result[key])
+
+    print(f"[INFO] Created {len(overall['created'])}: {overall['created']}")
+    print(f"[INFO] Updated {len(overall['updated'])}: {overall['updated']}")
+    print(
+        f"[INFO] Skipped {len(overall['skipped'])} (already up to date): {overall['skipped']}"  # noqa
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync-airtable.yml
+++ b/.github/workflows/sync-airtable.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Sync spiders to Airtable
         env:
-          AIRTABLE_PAT: ${{ secrets.AIRTABLE_PAT }}
-          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
-          AIRTABLE_TABLE: ${{ secrets.SLUGS_TABLE_ID }}
-          AIRTABLE_BACKLOG_TABLE: ${{ secrets.BACKLOG_TABLE_ID }}
-        run: python .city-scrapers-core/.github/scripts/sync_spiders.py ${{ steps.changed.outputs.all_changed_files }}
+          CS_AIRTABLE_PAT: ${{ secrets.CS_AIRTABLE_PAT }}
+          CS_AIRTABLE_BASE_ID: ${{ secrets.CS_AIRTABLE_BASE_ID }}
+          CS_SLUGS_TABLE_ID: ${{ secrets.CS_SLUGS_TABLE_ID }}
+          CS_BACKLOG_TABLE_ID: ${{ secrets.CS_BACKLOG_TABLE_ID }}
+        run: python .city-scrapers-core/.github/scripts/sync_airtable.py ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/sync-airtable.yml
+++ b/.github/workflows/sync-airtable.yml
@@ -13,14 +13,17 @@ on:
         required: false
         type: string
         default: 'main'
+      CS_AIRTABLE_BASE_ID:
+        required: true
+        type: string
+      CS_SLUGS_TABLE_ID:
+        required: true
+        type: string
+      CS_BACKLOG_TABLE_ID:
+        required: true
+        type: string
     secrets:
-      AIRTABLE_PAT:
-        required: true
-      AIRTABLE_BASE_ID:
-        required: true
-      SLUGS_TABLE_ID:
-        required: true
-      BACKLOG_TABLE_ID:
+      CS_AIRTABLE_PAT:
         required: true
 
 jobs:
@@ -59,7 +62,7 @@ jobs:
       - name: Sync spiders to Airtable
         env:
           CS_AIRTABLE_PAT: ${{ secrets.CS_AIRTABLE_PAT }}
-          CS_AIRTABLE_BASE_ID: ${{ secrets.CS_AIRTABLE_BASE_ID }}
-          CS_SLUGS_TABLE_ID: ${{ secrets.CS_SLUGS_TABLE_ID }}
-          CS_BACKLOG_TABLE_ID: ${{ secrets.CS_BACKLOG_TABLE_ID }}
+          CS_AIRTABLE_BASE_ID: ${{ inputs.CS_AIRTABLE_BASE_ID }}
+          CS_SLUGS_TABLE_ID: ${{ inputs.CS_SLUGS_TABLE_ID }}
+          CS_BACKLOG_TABLE_ID: ${{ inputs.CS_BACKLOG_TABLE_ID }}
         run: python .city-scrapers-core/.github/scripts/sync_airtable.py ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/sync-airtable.yml
+++ b/.github/workflows/sync-airtable.yml
@@ -1,0 +1,65 @@
+name: Sync spiders to Airtable (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'Python version to use'
+        required: false
+        type: string
+        default: '3.11'
+      core-ref:
+        description: 'Branch/tag/SHA of city-scrapers-core to use for the script'
+        required: false
+        type: string
+        default: 'main'
+    secrets:
+      AIRTABLE_PAT:
+        required: true
+      AIRTABLE_BASE_ID:
+        required: true
+      SLUGS_TABLE_ID:
+        required: true
+      BACKLOG_TABLE_ID:
+        required: true
+
+jobs:
+  sync-airtable:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the consumer repo (the one whose PR triggered this).
+      # No `repository:` means default — the caller's repo.
+      - name: Check out consumer repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Check out city-scrapers-core into a sibling directory so the script
+      # is available to run.
+      - name: Check out city-scrapers-core
+        uses: actions/checkout@v4
+        with:
+          repository: City-Bureau/city-scrapers-core
+          ref: ${{ inputs.core-ref }}
+          path: .city-scrapers-core
+
+      - uses: tj-actions/changed-files@v45
+        id: changed
+        with:
+          files: city_scrapers/spiders/**.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install script dependencies
+        run: pip install pyairtable python-decouple
+
+      - name: Sync spiders to Airtable
+        env:
+          AIRTABLE_PAT: ${{ secrets.AIRTABLE_PAT }}
+          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
+          AIRTABLE_TABLE: ${{ secrets.SLUGS_TABLE_ID }}
+          AIRTABLE_BACKLOG_TABLE: ${{ secrets.BACKLOG_TABLE_ID }}
+        run: python .city-scrapers-core/.github/scripts/sync_spiders.py ${{ steps.changed.outputs.all_changed_files }}


### PR DESCRIPTION
## What does this PR do?
This PR adds a GitHub Actions workflow that automatically syncs spider metadata (name, agency, and program) to our Airtable tracking table whenever a pull request adds or modifies a scraper.

When a PR adds/updates any file under city_scrapers/spiders/, the workflow parses each changed file and extracts the spider's name (slug) and agency, handling both singular scrapers (class attributes) and spider factories (`spider_configs` list). It then looks up each agency in the Airtable table and either updates its slug if it has changed, or creates a new record if the agency isn't already tracked. The workflow also finds the scraper being added from the PR in the airtable backlog, and syncs the matched records 'Program' value in the slugs/spiders tracking table.
The workflow consists of:
- `.github/workflows/sync-airtable.yml` - the workflow definition, triggered on PR open/synchronize/reopen.
- `.github/scripts/sync_spiders.py` - the Python script that parses spider files using `ast` and update/insert records to Airtable via `pyairtable`.

## Why are we doing this?
QA of every newly added scraper previously required to open each spider file by hand, locate the name and agency values (including digging through `spider_configs` list for spider factories), and manually copy them into the Airtable. This process was tedious and error-prone, slugs could be mistyped, spiders inside factory configs could be missed entirely, and updates to existing scrapers required a second manual pass to keep Airtable in sync.
This workflow eliminates the manual step by extracting the relevant fields directly from the source of truth (the scraper file itself) and syncing them to Airtable on every PR.

## Steps to test
The reusable workflow only runs when a consumer repository (any city scrapers repo) makes a call to the `sync-airtable.yml` file. After merging:
- Update any open PR that adds or modifies a scraper with a consumer yml file making a call to `City-Bureau/city-scrapers-core/.github/workflows/sync-airtable.yml@main`.
- The workflow will run automatically on the PR.
- Confirm that the spider name[s] and agency[ies] from the changed spider file[s] appear in the corresponding Airtable table.

## Are there any smells or added technical debt to note?
The sync logic uses agency as the lookup key in the Airtable and updates the slug field when a match is found. This was a deliberate choice because agency is the more stable value (human-readable, not often edited), while slug is the one that can change as scrapers get renamed or restructured.
The tradeoff: if an agency string in a spider file is ever edited (for example, to fix a typo or rename the agency), the workflow will treat it as a new agency and create a fresh record rather than updating the existing one. The table will then contain two records for effectively the same scraper, the old one with the outdated agency name, and the new one with the current values. In such a case, we'd have to manually cleanup the Airtable to remove the stale record.
