### PR TITLE
Airtable sync workflow update: added syncing for additional fields

### DIFF
--- a/.github/scripts/spiders_to_json.py
+++ b/.github/scripts/spiders_to_json.py
@@ -65,13 +65,19 @@ def extract_spiders(source: str) -> list[dict]:
             for element in node.value.elts:
                 if not isinstance(element, ast.Dict):
                     continue
-                entry = {"name": None, "agency": None}
+                entry = {
+                    "name": None,
+                    "agency": None,
+                    "agency_name": None,
+                }
                 for k, v in zip(element.keys, element.values):
                     if not (
                         isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
                     ):
                         continue
-                    if k.value in ("name", "agency") and isinstance(v.value, str):
+                    if k.value in ("name", "agency", "agency_name") and isinstance(
+                        v.value, str
+                    ):
                         entry[k.value] = v.value
                 if entry["name"]:
                     spiders.append(entry)

--- a/.github/scripts/sync_from_json.py
+++ b/.github/scripts/sync_from_json.py
@@ -197,6 +197,7 @@ def sync_to_airtable(
 
     Returns a summary: {'created': [...], 'updated': [...]}.
     """
+    transfer_values = transfer_values or {}
     extra_fields: dict[str, object] = {}
 
     program_id = transfer_values.get("program_id")

--- a/.github/scripts/sync_from_json.py
+++ b/.github/scripts/sync_from_json.py
@@ -20,17 +20,27 @@ AirTable field IDs.
 Comment annotation: Field name / Table name
 """
 
-# Slug / 'Spider / subscraper QA tracker'
-SLUG_FIELD_ID = "fld7JlLahrbFlmLMk"
-# Program / 'Spider / subscraper QA tracker'
-PROGRAM_FIELD_ID = "fld83rWaVrVoKBNve"
-# Agency name / 'Spider / subscraper QA tracker'
+# Agency name / Slug table
 AGENCY_FIELD_ID = "fldM4p8WnXekL1IhH"
+# Slug / Slug table
+SLUG_FIELD_ID = "fld7JlLahrbFlmLMk"
+# Program / Slug table
+PROGRAM_FIELD_ID = "fld83rWaVrVoKBNve"
+# Batch / Slug table
+BATCH_FIELD_ID = "fldl8dARiHn995dCy"
+# Scraper type / Slug table
+SCRAPER_TYPE_FIELD_ID = "fld0Ma77mkizVIucu"
+# Original Backlog Request / Slug table
+BACKLOG_REQUEST_FIELD_ID = "fld8lW7mx696sICmF"
 
 # Agency name / Backlog
 BACKLOG_AGENCY_FIELD_ID = "fld30MsEoonhPTP4Z"
-# Agency name / Backlog
+# Program / Backlog
 BACKLOG_PROGRAM_LOOKUP_FIELD_ID = "fldDJcsvXPlvbK5FY"
+# Scraper type / Backlog
+BACKLOG_SCRAPER_TYPE_FIELD_ID = "fldGeEh3yoZMDBnC6"
+# Batch / Backlog
+BACKLOG_BATCH_FIELD_ID = "fldfdd7z3jt1YP3DM"
 
 # Validation limits
 MAX_FILES = 10  # PR can't touch more than this many spider files
@@ -82,11 +92,18 @@ def validate_artifact(data) -> list[dict]:
                 continue
             name = s.get("name")
             agency = s.get("agency")
+            agency_name = s.get("agency_name")
             if not isinstance(name, str) or not name:
                 continue
             if agency is not None and not isinstance(agency, str):
                 continue
-            clean_spiders.append({"name": name, "agency": agency})
+            clean_spiders.append(
+                {
+                    "name": name,
+                    "agency": agency,
+                    "agency_name": agency_name,
+                }
+            )
 
         cleaned.append(
             {
@@ -98,40 +115,67 @@ def validate_artifact(data) -> list[dict]:
     return cleaned
 
 
-def find_program_for_agency(agency: str, backlog_table) -> str | None:
-    """
-    Look up `agency` in the Backlog table and return the linked Program record ID.
+def find_backlog_data_for_agency(agency_name: str, backlog_table) -> dict:
+    """Look up an agency in the Backlog table and return its relevant fields.
 
-    The Backlog table's Program field is a *lookup*, it returns
-    the linked program's record ID. This function Returns the
-    Programs record ID, or None if the agency isn't in Backlog or
-    the looked-up Program name doesn't resolve to a Programs record.
+    Returns a dict of values from the Backlog record, including the linked
+    Program record ID under the key 'program_id'. If the agency isn't in
+    Backlog, or the Program link is missing/invalid, 'program_id' is None.
+    Other fields are returned with type-appropriate empty defaults so callers
+    don't need to None-check each one.
     """
+    empty = {
+        "original_request": "",
+        "scraper_type": "",
+        "batch": "",
+        "program_id": None,
+    }
+
     backlog_records = backlog_table.all(
-        formula=match({BACKLOG_AGENCY_FIELD_ID: agency}),
-        fields=[BACKLOG_PROGRAM_LOOKUP_FIELD_ID],
+        formula=match({BACKLOG_AGENCY_FIELD_ID: agency_name}),
+        fields=[
+            BACKLOG_PROGRAM_LOOKUP_FIELD_ID,
+            BACKLOG_SCRAPER_TYPE_FIELD_ID,
+            BACKLOG_BATCH_FIELD_ID,
+        ],
         max_records=1,
         use_field_ids=True,
     )
+
     if not backlog_records:
-        return None
+        print(f"[INFO] No Backlog record found for agency {agency_name!r}")
+        return empty
+
+    record = backlog_records[0]
+    fields = record["fields"]
+
+    transfer_values = {
+        "original_request": record["id"],
+        "scraper_type": fields.get(BACKLOG_SCRAPER_TYPE_FIELD_ID, ""),
+        "batch": fields.get(BACKLOG_BATCH_FIELD_ID, ""),
+        "program_id": None,
+    }
+
     # Lookup fields always return a list, even when the source link is single.
-    program_links = (
-        backlog_records[0]["fields"].get(BACKLOG_PROGRAM_LOOKUP_FIELD_ID) or []
-    )
+    program_links = fields.get(BACKLOG_PROGRAM_LOOKUP_FIELD_ID) or []
     if not program_links:
-        return None
+        print(f"[INFO] Backlog record for {agency_name!r} has no linked Program")
+        return transfer_values
+
     candidate = program_links[0]
     if not is_valid_record_id(candidate):
         print(
-            f"[INFO] Backlog returned non-record-ID value for {agency!r}: {candidate!r}"
+            f"[INFO] Backlog returned non-record-ID value for "
+            f"{agency_name!r}: {candidate!r}"
         )
-        return None
-    return candidate
+        return transfer_values
+
+    transfer_values["program_id"] = candidate
+    return transfer_values
 
 
 def sync_to_airtable(
-    spiders: list[dict], table, table_records, program_record_id: str | None = None
+    spiders: list[dict], table, table_records, transfer_values=None
 ) -> dict:
     """
     Sync spiders to Airtable, keyed on agency name.
@@ -139,13 +183,8 @@ def sync_to_airtable(
     matching records.
 
     Workflow for each spider:
-      - If the agency is already in the table and the slug matches: skip.
-      - If the agency is in the table but the slug differs: update the slug.
+      - If the agency is already in the table: update the slug and any extra fields.
       - If the agency is not in the table: create a new record.
-
-    If `program_record_id` is provided, every created or updated record also
-    has its Program field set to link to that record. If None, the Program
-    field is left untouched.
 
     Note:
     If the agency name for the same slug changes, a new record
@@ -156,15 +195,33 @@ def sync_to_airtable(
     approach than accidentally overwriting an existing record
     with a new slug that belongs to a different agency.
 
-    Returns a summary: {'created': [...], 'updated': [...], 'skipped': [...]}.
+    Returns a summary: {'created': [...], 'updated': [...]}.
     """
+    extra_fields: dict[str, object] = {}
+
+    program_id = transfer_values.get("program_id")
+    if program_id:
+        extra_fields[PROGRAM_FIELD_ID] = [program_id]
+
+    batch = transfer_values.get("batch")
+    if batch:
+        extra_fields[BATCH_FIELD_ID] = batch
+
+    scraper_type = transfer_values.get("scraper_type")
+    if scraper_type:
+        extra_fields[SCRAPER_TYPE_FIELD_ID] = scraper_type
+
+    original_request_id = transfer_values.get("original_request")
+    if original_request_id:
+        extra_fields[BACKLOG_REQUEST_FIELD_ID] = [original_request_id]
+
     existing: dict[str, tuple[str, str]] = {}
     for r in table_records:
         agency = r["fields"].get(AGENCY_FIELD_ID)
         if agency:
-            existing[agency] = (r["id"], r["fields"].get(SLUG_FIELD_ID, ""))
+            existing[agency] = r["id"]
 
-    to_create, to_update, skipped = [], [], []
+    to_create, to_update = [], []
 
     for spider in spiders:
         slug = spider["name"]
@@ -175,20 +232,13 @@ def sync_to_airtable(
             continue
 
         if agency in existing:
-            record_id, current_slug = existing[agency]
-            if current_slug == slug:
-                skipped.append(agency)
-            else:
-                fields = {SLUG_FIELD_ID: slug}
-                if program_record_id:
-                    fields[PROGRAM_FIELD_ID] = [program_record_id]
-                to_update.append({"id": record_id, "fields": fields})
+            record_id = existing[agency]
+            fields = {SLUG_FIELD_ID: slug, **extra_fields}
+            to_update.append({"id": record_id, "fields": fields})
         else:
-            fields = {SLUG_FIELD_ID: slug, AGENCY_FIELD_ID: agency}
-            if program_record_id:
-                fields[PROGRAM_FIELD_ID] = [program_record_id]
+            fields = {SLUG_FIELD_ID: slug, AGENCY_FIELD_ID: agency, **extra_fields}
             to_create.append(fields)
-            existing[agency] = ("", slug)
+            existing[agency] = ""
 
     created = []
     if to_create:
@@ -202,7 +252,7 @@ def sync_to_airtable(
         table.batch_update(to_update, use_field_ids=True)
         updated = [u["fields"][SLUG_FIELD_ID] for u in to_update]
 
-    return {"created": created, "updated": updated, "skipped": skipped}
+    return {"created": created, "updated": updated}
 
 
 def main():
@@ -227,29 +277,47 @@ def main():
         use_field_ids=True,
     )
 
-    overall = {"created": [], "updated": [], "skipped": []}
+    overall = {"created": [], "updated": []}
     for entry in file_entries:
         spiders = entry["spiders"]
         if not spiders:
             continue
 
-        program_id = None
+        transfer_values = {}
         for spider in spiders:
-            agency = spider.get("agency")
-            if agency and (
-                program_id := find_program_for_agency(agency, backlog_table)
-            ):
+            lookup_name = spider.get("agency_name") or spider.get("agency")
+            if not lookup_name:
+                print(
+                    f"[INFO] skipping spider {spider.get('name')!r} - "
+                    "no agency name for Backlog lookup"
+                )
+                continue
+
+            transfer_values = find_backlog_data_for_agency(lookup_name, backlog_table)
+            if transfer_values.get("program_id"):
                 break
 
-        result = sync_to_airtable(spiders, slugs_table, slugs_table_records, program_id)
+        """
+        A slug record will not be created or updated if none of the spiders in the file
+        have an agency that matches a Backlog record. This is a safeguard to prevent
+        creating/updating records based on unverified agency names, which could lead to
+        incorrect data in Airtable.
+        """
+        if not transfer_values.get("original_request"):
+            print(
+                f"[INFO] No Backlog record matched any spider in {entry['path']!r}; "
+                "skipping file"
+            )
+            continue
+
+        result = sync_to_airtable(
+            spiders, slugs_table, slugs_table_records, transfer_values
+        )
         for key in overall:
             overall[key].extend(result[key])
 
     print(f"[INFO] Created {len(overall['created'])}: {overall['created']}")
     print(f"[INFO] Updated {len(overall['updated'])}: {overall['updated']}")
-    print(
-        f"[INFO] Skipped {len(overall['skipped'])} (already up to date): {overall['skipped']}"  # noqa
-    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/sync_from_json.py
+++ b/.github/scripts/sync_from_json.py
@@ -97,6 +97,8 @@ def validate_artifact(data) -> list[dict]:
                 continue
             if agency is not None and not isinstance(agency, str):
                 continue
+            if agency_name is not None and not isinstance(agency_name, str):
+                continue
             clean_spiders.append(
                 {
                     "name": name,
@@ -115,7 +117,9 @@ def validate_artifact(data) -> list[dict]:
     return cleaned
 
 
-def find_backlog_data_for_agency(agency_name: str, backlog_table) -> dict:
+def find_backlog_data_for_agency(
+    agency_name: str, backlog_table
+) -> dict[str, str | list[str] | None]:
     """Look up an agency in the Backlog table and return its relevant fields.
 
     Returns a dict of values from the Backlog record, including the linked
@@ -198,7 +202,7 @@ def sync_to_airtable(
     Returns a summary: {'created': [...], 'updated': [...]}.
     """
     transfer_values = transfer_values or {}
-    extra_fields: dict[str, object] = {}
+    extra_fields: dict[str, str | list[str]] = {}
 
     program_id = transfer_values.get("program_id")
     if program_id:
@@ -216,7 +220,7 @@ def sync_to_airtable(
     if original_request_id:
         extra_fields[BACKLOG_REQUEST_FIELD_ID] = [original_request_id]
 
-    existing: dict[str, tuple[str, str]] = {}
+    existing: dict[str, str] = {}
     for r in table_records:
         agency = r["fields"].get(AGENCY_FIELD_ID)
         if agency:
@@ -294,10 +298,12 @@ def main():
                 )
                 continue
 
-            transfer_values = find_backlog_data_for_agency(lookup_name, backlog_table)
-            if transfer_values.get("program_id"):
-                break
-
+            candidate_values = find_backlog_data_for_agency(lookup_name, backlog_table)
+            if candidate_values.get("original_request"):
+                if not transfer_values or candidate_values.get("program_id"):
+                    transfer_values = candidate_values
+                if candidate_values.get("program_id"):
+                    break
         """
         A slug record will not be created or updated if none of the spiders in the file
         have an agency that matches a Backlog record. This is a safeguard to prevent


### PR DESCRIPTION
Related [discussion](https://codethedream.slack.com/archives/C0833NP35RN/p1779824369242859)

- Added a few additional fields into the `sync_from_json` script to transfer from the backlog table to the slugs table while syncing.
- During the update process of a found slug record in the `sync_from_json` script, now if the same record is found it gets updated with all of the field values related to the keyed agency from the backlog table. This process used to get skipped if an agency match was found in the slugs table.